### PR TITLE
Add UpperCaseWords to default set of filters.

### DIFF
--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -87,6 +87,7 @@ class FilterPluginManager extends AbstractPluginManager
         'striptags'                  => 'Zend\Filter\StripTags',
         'toint'                      => 'Zend\Filter\ToInt',
         'tonull'                     => 'Zend\Filter\ToNull',
+        'uppercasewords'             => 'Zend\Filter\UpperCaseWords',
         'urinormalize'               => 'Zend\Filter\UriNormalize',
         'whitelist'                  => 'Zend\Filter\Whitelist',
         'wordcamelcasetodash'        => 'Zend\Filter\Word\CamelCaseToDash',


### PR DESCRIPTION
Because:

`Zend\Filter\FilterPluginManager::get was unable to fetch or create an instance for UpperCaseWords`