### PR TITLE
Expose as a standalone component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\Filter",
+            "config-provider": "Zend\\Filter\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-filter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+class ConfigProvider
+{
+    /**
+     * Return configuration for this component.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Return dependency mappings for this component.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'factories' => [
+                'FilterManager' => FilterPluginManagerFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/FilterPluginManagerFactory.php
+++ b/src/FilterPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-filter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FilterPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FilterPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new FilterPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return FilterPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: FilterPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-filter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+class Module
+{
+    /**
+     * Return default zend-filter configuration for zend-mvc applications.
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Register a specification for the FilterManager with the ServiceListener.
+     *
+     * @param \Zend\ModuleManager\ModuleEvent
+     * @return void
+     */
+    public function init($event)
+    {
+        $container = $event->getParam('ServiceManager');
+        $serviceListener = $container->get('ServiceListener');
+
+        $serviceListener->addServiceManager(
+            'FilterManager',
+            'filters',
+            'Zend\ModuleManager\Feature\FilterProviderInterface',
+            'getFilterConfig'
+        );
+    }
+}

--- a/test/FilterPluginManagerFactoryTest.php
+++ b/test/FilterPluginManagerFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-filter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Filter;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Filter\FilterPluginManager;
+use Zend\Filter\FilterPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FilterPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new FilterPluginManagerFactory();
+
+        $filters = $factory($container, FilterPluginManagerFactory::class);
+        $this->assertInstanceOf(FilterPluginManager::class, $filters);
+
+        if (method_exists($filters, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $filters);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $filters->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $filter = function ($value) {
+            return $value;
+        };
+
+        $factory = new FilterPluginManagerFactory();
+        $filters = $factory($container, FilterPluginManagerFactory::class, [
+            'services' => [
+                'test' => $filter,
+            ],
+        ]);
+        $this->assertSame($filter, $filters->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $filter = function ($value) {
+            return $value;
+        };
+
+        $factory = new FilterPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $filter,
+            ],
+        ]);
+
+        $filters = $factory->createService($container->reveal());
+        $this->assertSame($filter, $filters->get('test'));
+    }
+}


### PR DESCRIPTION
Per [the zend-mvc v3 roadmap](https://github.com/zendframework/maintainers/wiki/zend-mvc-v3-refactor:-reduce-components), this patch does the following:

- Adds a factory for the `FilterPluginManager` (along with tests).
- Adds a `ConfigProvider` to allow mapping the `FilterManager` service to the above factory in generic applications.
- Adds a `Module` to do the same as the `ConfigProvider`, but for zend-mvc applications; the `Module` also exposes an `init()` method for notifying the service listener of the `FilterManager` specification.
- Adds entries in `composer.json` to expose the package as a config provider and a ZF component.