### PR TITLE
Add "scripts" section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,16 @@
         "psr-4": {
             "ZendTest\\Filter\\": "test/"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "upload-coverage": "coveralls -v",
+        "cs-check": "php-cs-fixer --version && php-cs-fixer fix -v --diff --dry-run",
+        "cs-fix": "php-cs-fixer fix -v",
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-clover clover.xml"
     }
 }


### PR DESCRIPTION
Adds composer script support (eg: "composer test") like other components have (eg: [zend-mvc](https://github.com/zendframework/zend-mvc/blob/master/composer.json#L54), [zend-soap](https://github.com/zendframework/zend-soap/blob/master/composer.json#L47))
