### PR TITLE
Callback filter consumes string class name via ::class resolution

### DIFF
--- a/doc/book/standard-filters.md
+++ b/doc/book/standard-filters.md
@@ -340,6 +340,19 @@ $filter = new Zend\Filter\Callback(array('MyClass', 'reverse'));
 print $filter->filter('Hello!');
 ```
 
+As of PHP 5.5 you can use ::class resolution for given callback class:
+
+```php
+class MyClass
+{
+    public function __invoke($param);
+}
+
+// The filter definition
+$filter = new Zend\Filter\Callback(MyClass::class);
+print $filter->filter('Hello!');
+```
+
 To get the actual set callback use `getCallback()` and to set another callback
 use `setCallback()`.
 

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -27,7 +27,7 @@ class Callback extends AbstractFilter
      */
     public function __construct($callbackOrOptions = [], $callbackParams = [])
     {
-        if (is_callable($callbackOrOptions)) {
+        if (is_callable($callbackOrOptions) || is_string($callbackOrOptions)) {
             $this->setCallback($callbackOrOptions);
             $this->setCallbackParams($callbackParams);
         } else {
@@ -44,6 +44,10 @@ class Callback extends AbstractFilter
      */
     public function setCallback($callback)
     {
+        if (is_string($callback) && class_exists($callback)) {
+            $callback = new $callback();
+        }
+
         if (!is_callable($callback)) {
             throw new Exception\InvalidArgumentException(
                 'Invalid parameter for callback: must be callable'

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -40,6 +40,12 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('staticCallback-test', $filter('test'));
     }
 
+    public function testStringClassCallback()
+    {
+        $filter = new CallbackFilter(self::class);
+        $this->assertEquals('stringClassCallback-test', $filter('test'));
+    }
+
     public function testSettingDefaultOptions()
     {
         $filter = new CallbackFilter([$this, 'objectCallback'], 'param');
@@ -75,6 +81,11 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     public static function staticCallback($value)
     {
         return 'staticCallback-' . $value;
+    }
+
+    public function __invoke($value)
+    {
+        return 'stringClassCallback-' . $value;
     }
 
     public function objectCallbackWithParams($value, $param = null)


### PR DESCRIPTION
Added ability to inject string class name into callback filter constructor.
