### PR TITLE
Improve handling of digits in CamelCaseToSeparator filter

### DIFF
--- a/src/Word/CamelCaseToSeparator.php
+++ b/src/Word/CamelCaseToSeparator.php
@@ -26,10 +26,18 @@ class CamelCaseToSeparator extends AbstractSeparator
         }
 
         if (StringUtils::hasPcreUnicodeSupport()) {
-            $pattern     = ['#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#'];
-            $replacement = [$this->separator . '\1', $this->separator . '\1'];
+            /**
+             * First: Match right after a lowercase letter or digit following a capital letter or
+             * before a capital letter with a lowercese letter on it's right.
+             *
+             * Second: Match right after a lowercase letter following zero or more digits
+             * or a capital letter
+             */
+            $pattern = ['#(?<=\p{Ll}|\p{Nd})(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}))(\p{Lu}|(\p{Nd}+))#'];
+            $replacement = [ $this->separator . '\1', $this->separator . '\1',
+            ];
         } else {
-            $pattern     = ['#(?<=(?:[A-Z]))([A-Z]+)([A-Z][a-z])#', '#(?<=(?:[a-z0-9]))([A-Z])#'];
+            $pattern     = [ '#(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])#', '#(?<=(?:[a-z]))([A-Z]|([0-9]+))#' ];
             $replacement = ['\1' . $this->separator . '\2', $this->separator . '\1'];
         }
 

--- a/test/Word/CamelCaseToDashTest.php
+++ b/test/Word/CamelCaseToDashTest.php
@@ -23,4 +23,31 @@ class CamelCaseToDashTest extends TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('Camel-Cased-Words', $filtered);
     }
+
+    /**
+     * @dataProvider camelizedStrings
+     */
+    public function testFilterSeparatesCamelCasedWordsContainingNumbersWithDashes($camel, $dashed)
+    {
+        $filter   = new CamelCaseToDashFilter();
+        $filtered = $filter($camel);
+        $this->assertNotEquals($camel, $filtered);
+        $this->assertEquals($dashed, $filtered);
+    }
+
+    /**
+     * Provides CamelizedStrings to test
+     *
+     * @return array
+     */
+    public function camelizedStrings()
+    {
+        return [
+            [ 'CamelCasedWith2016Numbers', 'Camel-Cased-With-2016-Numbers' ],
+            [ '10NumbersAsPrefix', '10-Numbers-As-Prefix' ],
+            [ 'NumberSuffix42', 'Number-Suffix-42' ],
+            [ 'lower50Upper', 'lower-50-Upper' ],
+            [ 'dashed-2016Bar', 'dashed-2016-Bar'],
+        ];
+    }
 }

--- a/test/Word/CamelCaseToUnderscoreTest.php
+++ b/test/Word/CamelCaseToUnderscoreTest.php
@@ -38,13 +38,13 @@ class CamelCaseToUnderscoreTest extends TestCase
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Pa2_Title', $filtered);
+        $this->assertEquals('Pa_2_Title', $filtered);
 
         $string = 'Pa2aTitle';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Pa2a_Title', $filtered);
+        $this->assertEquals('Pa_2a_Title', $filtered);
     }
 }


### PR DESCRIPTION
This PR aims to add the behaviour asked in #33

Since the reason behind using the CamelCaseSeparator is tokenizing strings when case is changed, usual expectation is beginning a new token when hitting a number or digit.

I will try to summarize both current and changed behaviour on numbers with some examples:

| Original Text | Current | After this PR |
| --- | --- | --- |
| Foo2016Bar |  Foo2016-Bar | Foo-2016-Bar |
| March16Events | March16-Events |  March-16-Events |
| DigitSuffix42 | Digit-Suffix42 | Digit-Suffix-42 |
| 42metersLong | 42metersLong |  42-meters-Long |

> Notice the last example: Beginning of the word with lowercase letter after `42` is also mimics a case-change. I'm still not sure is this a acceptable/desired behaviour or not.

The issue #33 is about the `CamelCaseToDashFilter` but since it derived from `CamelCaseToSeparator` like `CamelCaseToUnderscore`, this change will affect both childs of `CamelCaseToSeparator`. For this reason, I also added more tests to `CamelCaseToDashTest`.

After digging dozen of approaches including other platforms such as Java and C# I came up with this final patterns with positive lookbehind and lookaheads. (Achieving same effect with a single regex seems like impossible, at least I give up)

I'm also aware of changing an existing test is not a good practice. Since the expected behaviour is changed for digits, I forced into touching the  `CamelCaseToUnderscoreTest`:
- Pa2_Title => Pa_2_Title
- Pa2a_Title => Pa_2a_Title

Altering the `CamelCaseToUnderscoreTest` seems like mandatory if the desired behaviour will be changed.

All tests are still green.
