### PR TITLE
Give php the absolute path to Traversable

### DIFF
--- a/src/Word/Service/SeparatorToSeparatorFactory.php
+++ b/src/Word/Service/SeparatorToSeparatorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Zend\Filter\Word\Service;
 
+use Traversable;
 use Interop\Container\ContainerInterface;
 use Zend\Filter\Word\SeparatorToSeparator;
 use Zend\ServiceManager\Exception\InvalidServiceException;


### PR DESCRIPTION
Without that use statement, the check would always be false. See https://3v4l.org/#preview
This was detected by etsy/phan, and the bug may or may not occur in real code.