### PR TITLE
Accept FilterInterface object in FilterChain

### DIFF
--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -149,6 +149,15 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function attach($callback, $priority = self::DEFAULT_PRIORITY)
     {
+        if (is_object($callback) && ! $callback instanceof \Closure) {
+            if (! $callback instanceof FilterInterface) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Expected a valid FilterInterface; received "%s"',
+                    (is_object($callback) ? get_class($callback) : gettype($callback))
+                ));
+            }
+        }
+
         if (! is_callable($callback)) {
             if (! $callback instanceof FilterInterface) {
                 throw new Exception\InvalidArgumentException(sprintf(

--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -149,13 +149,14 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function attach($callback, $priority = self::DEFAULT_PRIORITY)
     {
-        if (is_object($callback) && ! $callback instanceof \Closure) {
-            if (! $callback instanceof FilterInterface) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Expected a valid FilterInterface; received "%s"',
-                    (is_object($callback) ? get_class($callback) : gettype($callback))
-                ));
-            }
+        if (is_object($callback)
+            && ! $callback instanceof \Closure
+            && ! $callback instanceof FilterInterface
+        ) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expected a valid FilterInterface; received "%s"',
+                get_class($callback)
+            ));
         }
 
         if (! is_callable($callback)) {

--- a/test/BogusFilterMock.php
+++ b/test/BogusFilterMock.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Filter;
+
+/**
+ * Mock file for FilterChain
+ */
+class BogusFilterMock
+{
+    public function __invoke($a)
+    {
+        return $a;
+    }
+}

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -56,6 +56,17 @@ class FilterChainTest extends TestCase
         $this->assertEquals('abc', $chain->filter($value));
     }
 
+    public function testAllowsConnectingOnlyFilterInterfaceObjects()
+    {
+        $this->expectException(\Zend\Filter\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a valid FilterInterface; received "ZendTest\Filter\BogusFilterMock"');
+
+        $chain = new FilterChain();
+        $bogusFilter = new BogusFilterMock();
+
+        $chain->attach($bogusFilter);
+    }
+
     public function testAllowsConnectingViaClassShortName()
     {
         if (! function_exists('mb_strtolower')) {


### PR DESCRIPTION
When you attach a callable to the FilterChain it will be accepted without checking it is implementing the FilterInterface.

For example, we added by mistake a validator and because it implements the `__invoke` magic method, it was accepted in the filter chain creating some unexpected behavior. Sadly, this is an easy mistake to make when using the InputFactory when using arrays to configure it.

This PR should fix this problem.