### PR TITLE
Register FilterPluginManager by class name

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -31,6 +31,7 @@ class ConfigProvider
         return [
             'aliases' => [
                 'FilterManager' => FilterPluginManager::class,
+            ],
             'factories' => [
                 FilterPluginManager::class => FilterPluginManagerFactory::class,
             ],


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:
This quick fix adds `FilterPluginManager` class to be accessible in a same manner as in Validators but keeps `FilterManager` available as an alias.