### PR TITLE
remove unneeded (string) casting before cast to int in ToInt filter

### DIFF
--- a/src/ToInt.php
+++ b/src/ToInt.php
@@ -26,7 +26,6 @@ class ToInt extends AbstractFilter
         if (! is_scalar($value)) {
             return $value;
         }
-        $value = (string) $value;
 
         return (int) $value;
     }


### PR DESCRIPTION
- [x] Is this related to quality assurance?