### PR TITLE
Adds missing language to code block in documentation of file filters

### DIFF
--- a/docs/book/file.md
+++ b/docs/book/file.md
@@ -111,7 +111,7 @@ If you want to use a specific encoding when converting file content, you should
 specify the encoding when instantiating the `LowerCase` filter, or use the
 `setEncoding` method to change it.
 
-```
+```php
 use Zend\Filter\File\LowerCase;
 use Zend\Http\PhpEnvironment\Request;
 


### PR DESCRIPTION
The last code block can not be read: https://docs.zendframework.com/zend-filter/file/#basic-usage