### PR TITLE
Add int to constructor param type hint

### DIFF
--- a/src/ToNull.php
+++ b/src/ToNull.php
@@ -44,7 +44,7 @@ class ToNull extends AbstractFilter
     /**
      * Constructor
      *
-     * @param string|array|Traversable $typeOrOptions OPTIONAL
+     * @param int|string|array|Traversable $typeOrOptions OPTIONAL
      */
     public function __construct($typeOrOptions = null)
     {


### PR DESCRIPTION
Fixes `phpstan` errors when type a type constant is used in constructor, for example: `new ToNull(ToNull::TYPE_STRING)` results in

`Parameter #1 $typeOrOptions of class Zend\Filter\ToNull constructor expects array|string|Traversable|null, int given`
