### PR TITLE
Tar decompress works even if archive is not provided

### DIFF
--- a/src/Compress/Tar.php
+++ b/src/Compress/Tar.php
@@ -202,11 +202,12 @@ class Tar extends AbstractCompressionAlgorithm
     public function decompress($content)
     {
         $archive = $this->getArchive();
-        if (empty($archive) || ! file_exists($archive)) {
+        if (file_exists($content)) {
+            $archive = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, realpath($content));
+        } elseif (empty($archive) || ! file_exists($archive)) {
             throw new Exception\RuntimeException('Tar Archive not found');
         }
 
-        $archive = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, realpath($content));
         $archive = new Archive_Tar($archive, $this->getMode());
         $target  = $this->getTarget();
         if (! is_dir($target)) {

--- a/test/Compress/TarTest.php
+++ b/test/Compress/TarTest.php
@@ -209,4 +209,32 @@ class TarTest extends TestCase
         $filter = new TarCompression();
         $this->assertEquals('Tar', $filter->toString());
     }
+
+    /**
+     * @see https://github.com/zendframework/zend-filter/issues/41
+     */
+    public function testDecompressionDoesNotRequireArchive()
+    {
+        $filter = new TarCompression([
+            'archive' => $this->tmp . '/compressed.tar',
+            'target' => $this->tmp . '/zipextracted.txt',
+        ]);
+
+        $content = 'compress me ' . microtime(true);
+        $compressed = $filter->compress($content);
+
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar', $compressed);
+
+        $target = $this->tmp;
+        $filter = new TarCompression([
+            'target' => $target,
+        ]);
+
+        $decompressed = $filter->decompress($compressed);
+        self::assertSame($target, $decompressed);
+        // per documentation, tar includes full path
+        $file = $target . DIRECTORY_SEPARATOR . $target . DIRECTORY_SEPARATOR . '/zipextracted.txt';
+        self::assertFileExists($file);
+        self::assertSame($content, file_get_contents($file));
+    }
 }


### PR DESCRIPTION
We do not need provide archive on initialisation Tar object, as we can
provide link to the file to decompress directly in filter method.

Fixes #41

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
